### PR TITLE
refactor: ignore package.js detection

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
     ":automergeBranchPush",
     "group:allNonMajor"
   ],
+  "meteor": {
+    "enabled": false
+  },
   "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Nuxt has same file name `package.js` by accident which is scanning by renovate, so just disable it.