### PR TITLE
fix: move commitMessageTopic inside npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
         "enabled": false
       },
       "rangeStrategy": "bump",
-      "commitMessageTopic": "{{prettyDepType}} {{depName}}"
+      "npm": {
+        "commitMessageTopic": "{{prettyDepType}} {{depName}}"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This probably won't make a visible difference anywhere right now, but it's best to locate this within the `npm` object as it's not applicable to other managers like Docker, etc.