### PR TITLE
docs: update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this into `renovate.json`:
 ```json
 {
   "extends": [
-    "@nuxtjs"
+    "github>nuxt/renovate-config-nuxt"
   ]
 }
 ```


### PR DESCRIPTION
I' m using this config in my project and the dashboard prints the following warning:
```
WARN: Using npm packages for Renovate presets is now deprecated. Please migrate to repository-based presets instead.
```