### PR TITLE
fix: scope node ignore to npm manager only

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,12 +19,9 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchDepNames": [
-        "node"
-      ],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchDepNames": ["node"],
       "enabled": false
     },
     {

--- a/default.json
+++ b/default.json
@@ -9,9 +9,6 @@
   "meteor": {
     "enabled": false
   },
-  "ignoreDeps": [
-    "node"
-  ],
   "rangeStrategy": "bump",
   "minimumReleaseAge": "25 hours",
   "npm": {
@@ -21,6 +18,15 @@
     "on Monday"
   ],
   "packageRules": [
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepNames": [
+        "node"
+      ],
+      "enabled": false
+    },
     {
       "groupName": "nuxt framework",
       "groupSlug": "nuxt",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

https://github.com/nuxt/nuxt/issues/35285

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->


The current configuration is blocking *all* node updates, including `node:lts` updates in the devcontainer dockerfile. This change removes that blanket block and adds a scoped block for `engines.node` in `package.json` which was the desired behaviour. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
