### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "npm run test"
   },
   "devDependencies": {
-    "renovate": "latest"
+    "renovate": "^44.11.1"
   },
   "packageManager": "pnpm@11.20.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       renovate:
-        specifier: latest
+        specifier: ^44.11.1
         version: 44.11.1(supports-color@7.2.0)(typanion@3.14.0)
 
 packages:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`latest` is a curse and can easily drift, or change wildly on lockfile regeneration